### PR TITLE
compatibility with numpy >= 1.16.3

### DIFF
--- a/ud_parser.py
+++ b/ud_parser.py
@@ -403,7 +403,7 @@ if __name__ == "__main__":
 
     # Load the data
     if args.embeddings:
-        with np.load(args.embeddings) as embeddings_npz:
+        with np.load(args.embeddings, allow_pickle=True) as embeddings_npz:
             args.embeddings_words = embeddings_npz["words"]
             args.embeddings_data = embeddings_npz["embeddings"]
             args.embeddings_size = args.embeddings_data.shape[1]


### PR DESCRIPTION
When trying to use --embeddings with an npz file produced by convert.py, numpy complains "Object arrays cannot be loaded when allow_pickle=False". Fix taken from MappaGnosis's solution on https://stackoverflow.com/questions/55890813/how-to-fix-object-arrays-cannot-be-loaded-when-allow-pickle-false-for-imdb-loa/56243777 and verified meaning on https://numpy.org/devdocs/reference/generated/numpy.load.html