### PR TITLE
Handle missing semicolon in lemma rule

### DIFF
--- a/ud_dataset.py
+++ b/ud_dataset.py
@@ -51,7 +51,7 @@ def _gen_lemma_rule(form, lemma, allow_copy):
 
 def _apply_lemma_rule(form, lemma_rule):
     if ';' not in lemma_rule:
-        raise ValueError('lemma_rule %r for form %r missing semicolon.\n' %(lemma_rule, form))
+        raise ValueError('lemma_rule %r for form %r missing semicolon' %(lemma_rule, form))
     casing, rule = lemma_rule.split(";", 1)
     if rule.startswith("a"):
         lemma = rule[1:]

--- a/ud_dataset.py
+++ b/ud_dataset.py
@@ -51,12 +51,7 @@ def _gen_lemma_rule(form, lemma, allow_copy):
 
 def _apply_lemma_rule(form, lemma_rule):
     if ';' not in lemma_rule:
-        import sys
-        sys.stderr.write(
-            'Warning: lemma_rule %r for form %r.'
-            ' Falling back to copying form.\n' %(lemma_rule, form)
-        )
-        return form
+        raise ValueError('lemma_rule %r for form %r missing semicolon.\n' %(lemma_rule, form))
     casing, rule = lemma_rule.split(";", 1)
     if rule.startswith("a"):
         lemma = rule[1:]

--- a/ud_dataset.py
+++ b/ud_dataset.py
@@ -50,6 +50,8 @@ def _gen_lemma_rule(form, lemma, allow_copy):
     return rule
 
 def _apply_lemma_rule(form, lemma_rule):
+    if ';' not in lemma_rule:
+        return form
     casing, rule = lemma_rule.split(";", 1)
     if rule.startswith("a"):
         lemma = rule[1:]

--- a/ud_dataset.py
+++ b/ud_dataset.py
@@ -51,6 +51,11 @@ def _gen_lemma_rule(form, lemma, allow_copy):
 
 def _apply_lemma_rule(form, lemma_rule):
     if ';' not in lemma_rule:
+        import sys
+        sys.stderr.write(
+            'Warning: lemma_rule %r for form %r.'
+            ' Falling back to copying form.\n' %(lemma_rule, form)
+        )
         return form
     casing, rule = lemma_rule.split(";", 1)
     if rule.startswith("a"):


### PR DESCRIPTION
In my experiments training on `conllu` output of other parsers I encountered the error below, which means udpipe-future learned a lemma rule missing the semicolon separating casing and rule. This patch sets the lemma to be identical to the token in this situation.

```
Traceback (most recent call last):
  File "/path/UDPipe-Future/ud_parser.py", line 541, in <module>
    dev_accuracy, metrics = network.evaluate("dev", dev, dev_conllu, args)
  File "/path/UDPipe-Future/ud_parser.py", line 335, in evaluate
    conllu = self.predict(dataset, True, args)
  File "/path/UDPipe-Future/ud_parser.py", line 327, in predict
    dataset.write_sentence(conllu, sentences, overrides)
  File "/path/UDPipe-Future/ud_dataset.py", line 365, in write_sentence
    field = _apply_lemma_rule(fields[-1], field)
  File "/path/UDPipe-Future/ud_dataset.py", line 53, in _apply_lemma_rule
    casing, rule = lemma_rule.split(";", 1)
ValueError: not enough values to unpack (expected 2, got 1)
```