### PR TITLE
support language or treebank embeddings

### DIFF
--- a/ud_dataset.py
+++ b/ud_dataset.py
@@ -115,9 +115,10 @@ class UDDataset:
     DEPREL = 6
     DEPS = 7
     MISC = 8
-    FACTORS = 9
-    EMBEDDINGS = 9
-    ELMO = 10
+    EXTRA = 9
+    FACTORS = 10
+    EMBEDDINGS = 10
+    ELMO = 11
 
     FACTORS_MAP = {"FORMS": FORMS, "LEMMAS": LEMMAS, "UPOS": UPOS, "XPOS": XPOS, "FEATS": FEATS,
                    "HEAD": HEAD, "DEPREL": DEPREL, "DEPS": DEPS, "MISC": MISC}
@@ -203,7 +204,14 @@ class UDDataset:
                                 factor.strings[-1].append(factor.words[factor.ROOT])
                                 if factor.characters: factor.charseq_ids[-1].append(factor.ROOT)
 
-                        word = columns[f]
+                        if f == self.EXTRA:
+                            word = 'n/a'
+                            for misc_field in columns[self.MISC].split('|'):
+                                if misc_field.startswith('ExtraInput='):
+                                    word = misc_field.split('=')[1]
+                                    break
+                        else:
+                            word = columns[f]
                         factor.strings[-1].append(word)
 
                         # Preprocess word

--- a/ud_dataset.py
+++ b/ud_dataset.py
@@ -367,6 +367,8 @@ class UDDataset:
             fields = []
             fields.append(str(i + 1))
             for f in range(self.FACTORS):
+                if f == self.EXTRA:
+                    continue
                 factor = self._factors[f]
                 offset = i + factor.with_root
 

--- a/ud_parser.py
+++ b/ud_parser.py
@@ -86,7 +86,7 @@ class Network:
                 inputs.append(self.elmo)
 
             # Extra input embeddings
-            if args.extra_input and args.extra_input_dim and num_extra_values > 1:
+            if self.extra_ids is not None:
                 extra_embeddings = tf.get_variable("extra_embeddings", shape=[num_extra_values, args.extra_input_dim], dtype=tf.float32)
                 inputs.append(tf.nn.embedding_lookup(extra_embeddings, self.extra_ids))
 

--- a/ud_parser.py
+++ b/ud_parser.py
@@ -388,7 +388,7 @@ if __name__ == "__main__":
     parser.add_argument("--embeddings", default=None, type=str, help="External embeddings to use.")
     parser.add_argument("--epochs", default="40:1e-3,20:1e-4", type=str, help="Epochs and learning rates.")
     parser.add_argument("--exp", default=None, type=str, help="Experiment name.")
-    parser.add_argument("--extra_input", default=False, action="store_true", help="Read ExtraInput=... from MISC column.")
+    parser.add_argument("--extra_input", default=None, type=str, help="Read extra input with this key from MISC column and comments.")
     parser.add_argument("--extra_input_dim", default=12, type=int, help="Extra input embedding dimension.")
     parser.add_argument("--label_smoothing", default=0.03, type=float, help="Label smoothing.")
     parser.add_argument("--logdir", default=None, type=str, help="Model and log directory.")
@@ -446,20 +446,25 @@ if __name__ == "__main__":
     if args.predict:
         train = ud_dataset.UDDataset("{}-ud-train.conllu".format(args.basename), root_factors,
                                      max_sentence_len=args.max_sentence_len,
-                                     embeddings=args.embeddings_words if args.embeddings else None)
-        test = ud_dataset.UDDataset(args.predict_input, root_factors, train=train, shuffle_batches=False, elmo=args.elmo)
+                                     embeddings=args.embeddings_words if args.embeddings else None,
+                                     extra_input_key = args.extra_input)
+        test = ud_dataset.UDDataset(args.predict_input, root_factors, train=train, shuffle_batches=False, elmo=args.elmo,
+                                    extra_input_key = args.extra_input)
     else:
         train = ud_dataset.UDDataset("{}-ud-train.conllu".format(args.basename), root_factors,
                                      max_sentence_len=args.max_sentence_len,
                                      embeddings=args.embeddings_words if args.embeddings else None,
-                                     elmo=re.sub("(?=,|$)", "-train.npz", args.elmo) if args.elmo else None)
+                                     elmo=re.sub("(?=,|$)", "-train.npz", args.elmo) if args.elmo else None,
+                                     extra_input_key = args.extra_input)
         if os.path.exists("{}-ud-dev.conllu".format(args.basename)):
             dev = ud_dataset.UDDataset("{}-ud-dev.conllu".format(args.basename), root_factors, train=train, shuffle_batches=False,
-                                       elmo=re.sub("(?=,|$)", "-dev.npz", args.elmo) if args.elmo else None)
+                                       elmo=re.sub("(?=,|$)", "-dev.npz", args.elmo) if args.elmo else None,
+                                       extra_input_key = args.extra_input)
         else:
             dev = None
         test = ud_dataset.UDDataset("{}-ud-test.conllu".format(args.basename), root_factors, train=train, shuffle_batches=False,
-                                    elmo=re.sub("(?=,|$)", "-test.npz", args.elmo) if args.elmo else None)
+                                    elmo=re.sub("(?=,|$)", "-test.npz", args.elmo) if args.elmo else None,
+                                    extra_input_key = args.extra_input)
     args.elmo_size = test.elmo_size
 
     # Ugly ensembling during prediction; should be refactored and merged with Network.predict


### PR DESCRIPTION
This PR provides support for language or treebank embeddings via annotating each token with `ExtraInput=<TREEBANK_ID>` in the MISC column (separated with `|` from `SpaceAfter=No` when not `_`) and calling the parser with `--extra_input`. I called it `ExtraInput` as it should be possible to use this for other input to the parser such as the output of a rule-based analyser. The parser continues to train on a single file. The user must add the `ExtraInput` annotation and concatenate the training files. 

For testing, I selected Finnish FTB + TDT as Stymne et al. 2018 showed +4.2 LAS improvements with treebank embeddings for this language and the treebanks for languages with higher improvements are either big (Russian) or only available on request (French). This PR achieves an error reduction of 9% compared to single treebank training and around 40% compared to training on the concatenation of the treebanks (without treebank embeddings).

Putting this here for discussion and feedback. Before accepting, it should be tested a bit more. In particular, I haven't checked the predict-only mode and I am not sure the new factor needs to be part of the root factors (but as far as I understand it does no harm).